### PR TITLE
Added ps1 script for Windows, edited .sh for UNIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ To read the details of the methodology: "Art is long, life is short: An SDG Clas
 A word of caution: this algorithm does not identify text that is outside the SDG scope. The scores represent an attempt to fit the entire text within the SDG vocabulary space. 
 
 ## Requires:
-Mallet 2.0.8 (http://mallet.cs.umass.edu)
-Text files to be classified (.txt)
-Covert your text files to .txt and clean them up as much as possible. The results will be better if you exclude non-relevant material (front matter, etc). 
+* Mallet 2.0.8 (http://mallet.cs.umass.edu)
+* Text files to be classified (.txt)
+* Covert your text files to .txt and clean them up as much as possible. The results will be better if you exclude non-relevant material (front matter, etc). 
 
 ### Tested on Mac OS X Big Sur, Windows and Linux:
 * on Mac, Zsh shell is preferred, tough the code should run in older Bash shell (pre-Catalina). 
 * On windows, bigrams command is broken. Need to apply this fix: https://github.com/mimno/Mallet/issues/151    
 
-## Mac OS Installation and use
+## Mac OS and UNIX Installation and use
 * From the Terminal shell, cd into the location you would like to install
 * clone the repository
 
@@ -41,12 +41,31 @@ rm mallet-2.0.8.zip
 ```
 * Results will be placed in /SDGclassy/target/output/scores-out.txt
 
-
 ## Windows Installation and use 
+* [Install WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+* Open a Powershell window inside the location you would like to install
+* Type `wsl` and follow the [Mac and UNIX installation steps and usage instructions](#mac-os-and-unix-installation-and-use)
 
+### Alternatively:
+* From Powershell, cd into the location you would like to install
+* clone the repository
 
-## Linux Installation and use
+```
+git clone https://github.com/SeaCelo/SDGclassy.git SDGclassy
+cd SDGclassy
+```
+* Install Mallet
 
+```
+wget http://mallet.cs.umass.edu/dist/mallet-2.0.8.zip -OutFile mallet-2.0.8.zip
+unzip mallet-2.0.8.zip
+rm mallet-2.0.8.zip
+```
+
+### How to use (with alternative method):
+* Add text files (txt only, no pdf, no directories) to: /SDGclassy/target/input/   
+* Run the classification script by right-clicking infer-scores.ps1 and selecting "Run with Powershell"
+* Results will be placed in /SDGclassy/target/output/scores-out.txt
 
 # Interpreting the Results
 * topics are listed in order 0-18. Each topic maps to a specific SDG, with one topic as a filter to be ignored. The mapping between topics and SDGs is available in: /classifier/topic-sdg_mapping.csv

--- a/infer-scores.ps1
+++ b/infer-scores.ps1
@@ -1,0 +1,25 @@
+[string]$d = Get-Location     # root path
+$c = 'sdg'                    # select classifier name
+$f = 'target'                 # select target files
+$w = 'extra-exclude-words.txt'
+
+Set-Location $env:MALLET_HOME
+
+bin/mallet import-dir `
+  --input $d/$f `
+  --output $d/$f/temp/inferring-$c.mallet `
+  --keep-sequence `
+  --remove-stopwords `
+  --extra-stopwords $d/classifier/$w `
+  --keep-sequence-bigrams `
+  --use-pipe-from $d/classifier/$c.mallet
+
+bin/mallet infer-topics `
+  --input $d/$f/temp/inferring-$c.mallet `
+  --inferencer $d/classifier/$c-inferencer.mallet `
+  --output-doc-topics $d/$f/output/scores-$c.txt
+
+Write-Output "Command sequence finished successfully. The results are available in /target/output/scores-$c.txt."
+Write-Output "The mapping between the results and the SDGs is available in /classifier/topic-sdg_mapping.csv."
+
+Pause

--- a/infer-scores.ps1
+++ b/infer-scores.ps1
@@ -1,25 +1,16 @@
-[string]$d = Get-Location     # root path
-$c = 'sdg'                    # select classifier name
-$f = 'target'                 # select target files
-$w = 'extra-exclude-words.txt'
-
-Set-Location $env:MALLET_HOME
-
-bin/mallet import-dir `
-  --input $d/$f `
-  --output $d/$f/temp/inferring-$c.mallet `
+mallet-2.0.8/bin/mallet import-dir `
+  --input ./target `
+  --output ./target/temp/inferring-sdg.mallet `
   --keep-sequence `
   --remove-stopwords `
-  --extra-stopwords $d/classifier/$w `
+  --extra-stopwords ./classifier/extra-exclude-words.txt `
   --keep-sequence-bigrams `
-  --use-pipe-from $d/classifier/$c.mallet
+  --use-pipe-from ./classifier/sdg.mallet
 
-bin/mallet infer-topics `
-  --input $d/$f/temp/inferring-$c.mallet `
-  --inferencer $d/classifier/$c-inferencer.mallet `
-  --output-doc-topics $d/$f/output/scores-$c.txt
+mallet-2.0.8/bin/mallet infer-topics `
+  --input ./target/temp/inferring-sdg.mallet `
+  --inferencer ./classifier/sdg-inferencer.mallet `
+  --output-doc-topics ./target/output/scores-out.txt
 
-Write-Output "Command sequence finished successfully. The results are available in /target/output/scores-$c.txt."
+Write-Output "Command sequence finished successfully. The results are available in /target/output/scores-out.txt."
 Write-Output "The mapping between the results and the SDGs is available in /classifier/topic-sdg_mapping.csv."
-
-Pause

--- a/infer-scores.sh
+++ b/infer-scores.sh
@@ -4,9 +4,9 @@ parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )  #we want to run M
 
 rm /target/input/.DS_Store || true   #we ignore any errors here
 
-"$parent_path"/mallet-2.0.8/bin/mallet import-dir --input /target/input  --output /target/temp/inferring-temp.mallet --keep-sequence --remove-stopwords --extra-stopwords /classifier/extra-exclude-words.txt --keep-sequence-bigrams --gram-sizes 1,2  --use-pipe-from /classifier/sdg.mallet   
+"$parent_path"/mallet-2.0.8/bin/mallet import-dir --input ./target/input  --output ./target/temp/inferring-temp.mallet --keep-sequence --remove-stopwords --extra-stopwords ./classifier/extra-exclude-words.txt --keep-sequence-bigrams --gram-sizes 1,2  --use-pipe-from ./classifier/sdg.mallet   
 
-"$parent_path"/mallet-2.0.8/bin/mallet infer-topics --input /target/temp/inferring-temp.mallet --inferencer /classifier/sdg-inferencer.mallet --output-doc-topics /target/output/scores-out.txt   
+"$parent_path"/mallet-2.0.8/bin/mallet infer-topics --input ./target/temp/inferring-temp.mallet --inferencer ./classifier/sdg-inferencer.mallet --output-doc-topics ./target/output/scores-out.txt   
 
 echo "Command sequence finished successfully. The results are available in /target/output/scores-out.txt."
 echo "The mapping between the results and the SDGs is available in /classifier/topic-sdg_mapping.csv."

--- a/target/output/.gitignore
+++ b/target/output/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything but .gitignore
+*
+!.gitignore


### PR DESCRIPTION
This is for running on Windows and UNIX.

To run on Ubuntu all that was needed was to prepend relative paths with `.`. That should not create any problems on Mac.

To run on Windows, you can either run the .ps1 script or use [wsl](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and run the .sh script from there like you would on UNIX.